### PR TITLE
Fix project.version usages that should be alliance.version

### DIFF
--- a/catalog-nsili-transformer/pom.xml
+++ b/catalog-nsili-transformer/pom.xml
@@ -73,10 +73,9 @@
         <dependency>
             <groupId>org.codice.alliance.catalog.core</groupId>
             <artifactId>catalog-core-api-impl</artifactId>
-            <version>${project.version}</version>
+            <version>${alliance.version}</version>
         </dependency>
     </dependencies>
-
 
     <build>
         <plugins>

--- a/nsili-app/pom.xml
+++ b/nsili-app/pom.xml
@@ -58,17 +58,17 @@
         <dependency>
             <groupId>org.codice.alliance.catalog.core</groupId>
             <artifactId>catalog-core-api</artifactId>
-            <version>${project.version}</version>
+            <version>${alliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codice.alliance.catalog.core</groupId>
             <artifactId>catalog-email-api</artifactId>
-            <version>${project.version}</version>
+            <version>${alliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codice.alliance.catalog.core</groupId>
             <artifactId>catalog-email-impl</artifactId>
-            <version>${project.version}</version>
+            <version>${alliance.version}</version>
         </dependency>
     </dependencies>
 

--- a/nsili-app/src/main/resources/features.xml
+++ b/nsili-app/src/main/resources/features.xml
@@ -30,8 +30,8 @@
     <feature name="catalog-email" version="${project.version}"
              description="Alliance Email Sending Service">
         <bundle>mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
-        <bundle>mvn:org.codice.alliance.catalog.core/catalog-email-api/${project.version}</bundle>
-        <bundle>mvn:org.codice.alliance.catalog.core/catalog-email-impl/${project.version}</bundle>
+        <bundle>mvn:org.codice.alliance.catalog.core/catalog-email-api/${alliance.version}</bundle>
+        <bundle>mvn:org.codice.alliance.catalog.core/catalog-email-impl/${alliance.version}</bundle>
     </feature>
 
     <feature name="catalog-nsili-source" version="${project.version}"
@@ -40,7 +40,7 @@
         <bundle>
             mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.9_1
         </bundle>
-        <bundle>mvn:org.codice.alliance.catalog.core/catalog-core-api/${project.version}</bundle>
+        <bundle>mvn:org.codice.alliance.catalog.core/catalog-core-api/${alliance.version}</bundle>
         <bundle>mvn:org.codice.alliance.nsili/catalog-nsili-source/${project.version}</bundle>
     </feature>
 
@@ -49,7 +49,7 @@
         <feature>catalog-nsili-orb-impl</feature>
         <feature>catalog-email</feature>
         <bundle>mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
-        <bundle>mvn:org.codice.alliance.catalog.core/catalog-core-api/${project.version}</bundle>
+        <bundle>mvn:org.codice.alliance.catalog.core/catalog-core-api/${alliance.version}</bundle>
         <bundle>mvn:org.codice.alliance.nsili/catalog-nsili-endpoint/${project.version}</bundle>
         <bundle>mvn:org.codice.alliance.nsili/catalog-nsili-sourcestoquery-ui/${project.version}</bundle>
     </feature>


### PR DESCRIPTION
#### What does this PR do?
Fixes project.version usages that should be alliance.version because the dependencies are defined in https://github.com/codice/alliance

<!--#### Who is reviewing it? 
-->
#### Choose 2 committers to review/merge the PR.
@ricklarsen - Documentation
@shaundmorris

<!--#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?

[CAL-xxx](https://codice.atlassian.net/browse/CAL-xxx)
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Threat Dragon models
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests-->